### PR TITLE
TestDSL

### DIFF
--- a/src/components/blockly/dsl/testdsl.ts
+++ b/src/components/blockly/dsl/testdsl.ts
@@ -9,10 +9,14 @@ import {
     OptionsInputDefinition,
     TextInputDefinition,
     testColour,
+    ValueInputDefinition,
+    BOOLEAN_TYPE,
 } from "../toolbox"
 import BlockDomainSpecificLanguage from "./dsl"
 
 const TEST_BLOCK = "test_test"
+const TEST_ASK_BLOCK = "test_ask"
+const TEST_CHECK_BLOCK = "test_check"
 const colour = testColour
 
 const testDsl: BlockDomainSpecificLanguage = {
@@ -20,7 +24,7 @@ const testDsl: BlockDomainSpecificLanguage = {
     createBlocks: () => [
         {
             kind: "block",
-            type: "test_test",
+            type: TEST_BLOCK,
             message0: `test %1 for %2`,
             args0: [
                 <TextInputDefinition>{
@@ -45,9 +49,45 @@ const testDsl: BlockDomainSpecificLanguage = {
                 },
             ],
             colour,
-            inputsInline: false,
+            inputsInline: true,
             tooltip: `Defines a new test for a service`,
             helpUrl: "",
+            nextStatement: CODE_STATEMENT_TYPE,
+        },
+        {
+            kind: "block",
+            type: TEST_ASK_BLOCK,
+            message0: `ask %1`,
+            args0: [
+                <TextInputDefinition>{
+                    type: "field_input",
+                    name: "question",
+                    text: "a question",
+                },
+            ],
+            colour,
+            inputsInline: true,
+            tooltip: `Asks a question to the user.`,
+            helpUrl: "",
+            previousStatement: CODE_STATEMENT_TYPE,
+            nextStatement: CODE_STATEMENT_TYPE,
+        },
+        {
+            kind: "block",
+            type: TEST_CHECK_BLOCK,
+            message0: `check %1`,
+            args0: [
+                <ValueInputDefinition>{
+                    type: "input_value",
+                    name: "expression",
+                    check: BOOLEAN_TYPE,
+                },
+            ],
+            colour,
+            inputsInline: true,
+            tooltip: `Checks that a boolean condition is true.`,
+            helpUrl: "",
+            previousStatement: CODE_STATEMENT_TYPE,
             nextStatement: CODE_STATEMENT_TYPE,
         },
     ],
@@ -60,6 +100,14 @@ const testDsl: BlockDomainSpecificLanguage = {
                 {
                     kind: "block",
                     type: TEST_BLOCK,
+                },
+                {
+                    kind: "block",
+                    type: TEST_ASK_BLOCK,
+                },
+                {
+                    kind: "block",
+                    type: TEST_CHECK_BLOCK,
                 },
             ],
         },

--- a/src/components/blockly/dsl/testdsl.ts
+++ b/src/components/blockly/dsl/testdsl.ts
@@ -1,0 +1,54 @@
+import { serviceSpecifications } from "../../../../jacdac-ts/src/jdom/spec"
+import {
+    OptionsInputDefinition,
+    TextInputDefinition,
+    toolsColour,
+} from "../toolbox"
+import BlockDomainSpecificLanguage from "./dsl"
+
+const TEST_BLOCK = "test_test"
+const colour = toolsColour
+
+const testDsl: BlockDomainSpecificLanguage = {
+    id: "test",
+    createBlocks: () => [
+        {
+            kind: "block",
+            type: "test_test",
+            message0: `test %1 for %2`,
+            args0: [
+                <TextInputDefinition>{
+                    type: "field_input",
+                    name: "name",
+                },
+                <OptionsInputDefinition>{
+                    type: "field_dropdown",
+                    name: "service",
+                    options: serviceSpecifications().map(spec => [
+                        spec.name,
+                        spec.shortId,
+                    ]),
+                },
+            ],
+            colour,
+            inputsInline: false,
+            tooltip: `Defines a new test for a service`,
+            helpUrl: "",
+        },
+    ],
+    createCategory: () => [
+        {
+            kind: "category",
+            name: "Tests",
+            colour: colour,
+            contents: [
+                {
+                    kind: "block",
+                    type: TEST_BLOCK,
+                },
+            ],
+        },
+    ],
+}
+
+export default testDsl

--- a/src/components/blockly/dsl/testdsl.ts
+++ b/src/components/blockly/dsl/testdsl.ts
@@ -1,22 +1,19 @@
 import {
-    SRV_BOOTLOADER,
-    SRV_CONTROL,
-    SRV_LOGGER,
-} from "../../../../jacdac-ts/jacdac-spec/dist/specconstants"
-import { serviceSpecifications } from "../../../../jacdac-ts/src/jdom/spec"
-import {
     CODE_STATEMENT_TYPE,
-    OptionsInputDefinition,
     TextInputDefinition,
     testColour,
     ValueInputDefinition,
     BOOLEAN_TYPE,
+    OptionsInputDefinition,
+    NUMBER_TYPE,
 } from "../toolbox"
 import BlockDomainSpecificLanguage from "./dsl"
 
 const TEST_BLOCK = "test_test"
 const TEST_ASK_BLOCK = "test_ask"
 const TEST_CHECK_BLOCK = "test_check"
+const TEST_CHANGES_BLOCK = "test_changes"
+const TEST_INCDEC_BY_BLOCK = "test_incdec_by"
 const colour = testColour
 
 const testDsl: BlockDomainSpecificLanguage = {
@@ -32,7 +29,6 @@ const testDsl: BlockDomainSpecificLanguage = {
                     name: "name",
                     text: "myTest",
                 },
-
             ],
             colour,
             inputsInline: true,
@@ -76,6 +72,54 @@ const testDsl: BlockDomainSpecificLanguage = {
             previousStatement: CODE_STATEMENT_TYPE,
             nextStatement: CODE_STATEMENT_TYPE,
         },
+        {
+            kind: "block",
+            type: TEST_CHANGES_BLOCK,
+            message0: `check %1 changes`,
+            args0: [
+                <ValueInputDefinition>{
+                    type: "input_value",
+                    name: "expression",
+                },
+            ],
+            colour,
+            inputsInline: true,
+            tooltip: `Checks that an expression changes of value.`,
+            helpUrl: "",
+            previousStatement: CODE_STATEMENT_TYPE,
+            nextStatement: CODE_STATEMENT_TYPE,
+        },
+        {
+            kind: "block",
+            type: TEST_INCDEC_BY_BLOCK,
+            message0: `check %1 %2 by %3`,
+            args0: [
+                <ValueInputDefinition>{
+                    type: "input_value",
+                    name: "expression",
+                    check: NUMBER_TYPE,
+                },
+                <OptionsInputDefinition>{
+                    type: "field_dropdown",
+                    name: "direction",
+                    options: [
+                        ["increments", "increments"],
+                        ["decrements", "decrements"],
+                    ],
+                },
+                <ValueInputDefinition>{
+                    type: "input_value",
+                    name: "threshold",
+                    check: NUMBER_TYPE,
+                },
+            ],
+            colour,
+            inputsInline: true,
+            tooltip: `Checks that an expression changes of value by a given threshold.`,
+            helpUrl: "",
+            previousStatement: CODE_STATEMENT_TYPE,
+            nextStatement: CODE_STATEMENT_TYPE,
+        },
     ],
     createCategory: () => [
         {
@@ -94,6 +138,14 @@ const testDsl: BlockDomainSpecificLanguage = {
                 {
                     kind: "block",
                     type: TEST_CHECK_BLOCK,
+                },
+                {
+                    kind: "block",
+                    type: TEST_CHANGES_BLOCK,
+                },
+                {
+                    kind: "block",
+                    type: TEST_INCDEC_BY_BLOCK,
                 },
             ],
         },

--- a/src/components/blockly/dsl/testdsl.ts
+++ b/src/components/blockly/dsl/testdsl.ts
@@ -1,13 +1,19 @@
+import {
+    SRV_BOOTLOADER,
+    SRV_CONTROL,
+    SRV_LOGGER,
+} from "../../../../jacdac-ts/jacdac-spec/dist/specconstants"
 import { serviceSpecifications } from "../../../../jacdac-ts/src/jdom/spec"
 import {
+    CODE_STATEMENT_TYPE,
     OptionsInputDefinition,
     TextInputDefinition,
-    toolsColour,
+    testColour,
 } from "../toolbox"
 import BlockDomainSpecificLanguage from "./dsl"
 
 const TEST_BLOCK = "test_test"
-const colour = toolsColour
+const colour = testColour
 
 const testDsl: BlockDomainSpecificLanguage = {
     id: "test",
@@ -20,20 +26,29 @@ const testDsl: BlockDomainSpecificLanguage = {
                 <TextInputDefinition>{
                     type: "field_input",
                     name: "name",
+                    text: "myTest",
                 },
                 <OptionsInputDefinition>{
                     type: "field_dropdown",
                     name: "service",
-                    options: serviceSpecifications().map(spec => [
-                        spec.name,
-                        spec.shortId,
-                    ]),
+                    options: serviceSpecifications()
+                        .filter(spec => spec.shortId[0] !== "_")
+                        .filter(
+                            spec =>
+                                [
+                                    SRV_CONTROL,
+                                    SRV_BOOTLOADER,
+                                    SRV_LOGGER,
+                                ].indexOf(spec.classIdentifier) < 0
+                        )
+                        .map(spec => [spec.name, spec.shortId]),
                 },
             ],
             colour,
             inputsInline: false,
             tooltip: `Defines a new test for a service`,
             helpUrl: "",
+            nextStatement: CODE_STATEMENT_TYPE,
         },
     ],
     createCategory: () => [

--- a/src/components/blockly/dsl/testdsl.ts
+++ b/src/components/blockly/dsl/testdsl.ts
@@ -25,28 +25,14 @@ const testDsl: BlockDomainSpecificLanguage = {
         {
             kind: "block",
             type: TEST_BLOCK,
-            message0: `test %1 for %2`,
+            message0: `test %1`,
             args0: [
                 <TextInputDefinition>{
                     type: "field_input",
                     name: "name",
                     text: "myTest",
                 },
-                <OptionsInputDefinition>{
-                    type: "field_dropdown",
-                    name: "service",
-                    options: serviceSpecifications()
-                        .filter(spec => spec.shortId[0] !== "_")
-                        .filter(
-                            spec =>
-                                [
-                                    SRV_CONTROL,
-                                    SRV_BOOTLOADER,
-                                    SRV_LOGGER,
-                                ].indexOf(spec.classIdentifier) < 0
-                        )
-                        .map(spec => [spec.name, spec.shortId]),
-                },
+
             ],
             colour,
             inputsInline: true,

--- a/src/components/blockly/toolbox.ts
+++ b/src/components/blockly/toolbox.ts
@@ -168,6 +168,7 @@ export const DATA_SCIENCE_STATEMENT_TYPE = "DataScienceStatement"
 export const TWIN_BLOCK = "jacdac_tools_twin"
 
 export const toolsColour = "#888"
+export const testColour = "#6FbA6A"
 
 export const CHART_WIDTH = 388
 export const CHART_HEIGHT = 240

--- a/src/components/blockly/useToolbox.ts
+++ b/src/components/blockly/useToolbox.ts
@@ -14,7 +14,6 @@ import {
     ToolboxConfiguration,
 } from "./toolbox"
 import { WorkspaceJSON } from "./jsongenerator"
-import { VMProgram } from "../../../jacdac-ts/src/vm/ir"
 import BlockDomainSpecificLanguage from "./dsl/dsl"
 
 // overrides blockly emboss filter for svg elements

--- a/src/components/vm/vmdsls.ts
+++ b/src/components/vm/vmdsls.ts
@@ -10,9 +10,11 @@ import jsonDsl from "../blockly/dsl/jsondsl"
 import chartDsl from "../blockly/dsl/chartdsl"
 import dataDsl from "../blockly/dsl/datadsl"
 import widgetDSL from "../blockly/dsl/widgetdsl"
+import testDsl from "../blockly/dsl/testdsl"
 
 const vmDsls = [
     servicesDSL,
+    testDsl,
     loopsDsl,
     logicDsl,
     mathDsl,


### PR DESCRIPTION
- started defining blocs to support authoring specification tests using VM.

@tballmsft if we go down this route, we should review which bloc will be needed.