### PR TITLE
fix to send Button event on joystick update

### DIFF
--- a/src/components/dashboard/DashboardJoystick.tsx
+++ b/src/components/dashboard/DashboardJoystick.tsx
@@ -46,7 +46,7 @@ function JoystickWidget(props: DashboardServiceProps) {
     }
     const onUpdate = (newx: number, newy: number) => {
         const [buttons] = server.reading.values()
-        server.reading.setValues([buttons, newx, newy])
+        server.updateDirection(buttons, newx, newy)
         register.refresh()
     }
     const { active, background, controlBackground } = useWidgetTheme(color)

--- a/src/pages/clients/makecode/extensions/joystick.mdx
+++ b/src/pages/clients/makecode/extensions/joystick.mdx
@@ -41,14 +41,14 @@ function plot(x: number, y: number) {
 
 ```blocks
 modules.joystick1.onButtonsChanged(function () {
-    const button = modules.joystick1.buttons()
-    if (button === jacdac.JoystickButtons.Left) {
+    let button = modules.joystick1.buttons()
+    if (button & jacdac.JoystickButtons.Left) {
         basic.showArrow(ArrowNames.West)
-    } else if (button === jacdac.JoystickButtons.Right) {
+    } else if (button & jacdac.JoystickButtons.Right) {
         basic.showArrow(ArrowNames.East)
-    } else if (button === jacdac.JoystickButtons.Up) {
+    } else if (button & jacdac.JoystickButtons.Up) {
         basic.showArrow(ArrowNames.North)
-    } else if (button === jacdac.JoystickButtons.Down) {
+    } else if (button & jacdac.JoystickButtons.Down) {
         basic.showArrow(ArrowNames.South)
     }
 })

--- a/src/pages/clients/makecode/extensions/joystick.mdx
+++ b/src/pages/clients/makecode/extensions/joystick.mdx
@@ -41,14 +41,13 @@ function plot(x: number, y: number) {
 
 ```blocks
 modules.joystick1.onButtonsChanged(function () {
-    let button = modules.joystick1.buttons()
-    if (button & jacdac.JoystickButtons.Left) {
+    if (modules.joystick1.isButtonDown(jacdac.JoystickButtons.Left)) {
         basic.showArrow(ArrowNames.West)
-    } else if (button & jacdac.JoystickButtons.Right) {
+    } else if (modules.joystick1.isButtonDown(jacdac.JoystickButtons.Right)) {
         basic.showArrow(ArrowNames.East)
-    } else if (button & jacdac.JoystickButtons.Up) {
+    } else if (modules.joystick1.isButtonDown(jacdac.JoystickButtons.Up)) {
         basic.showArrow(ArrowNames.North)
-    } else if (button & jacdac.JoystickButtons.Down) {
+    } else if (modules.joystick1.isButtonDown(jacdac.JoystickButtons.Down)) {
         basic.showArrow(ArrowNames.South)
     }
 })


### PR DESCRIPTION
Peli, the UI wasn't calling the server to update the button event (on movement of the stick).

The easiest way I found to fix this was to make updateDirection in joystickserver.ts public and call it directly (the method update uses Gamepad, which is not available in DashboardJoystick.tsx

