### PR TITLE
Makecode blocks/twins buttons QoL changes

### DIFF
--- a/src/components/buttons/StartMissingSimulatorsButton.tsx
+++ b/src/components/buttons/StartMissingSimulatorsButton.tsx
@@ -3,6 +3,7 @@ import DevicesIcon from "@mui/icons-material/Devices"
 import useRoleManagerClient from "../services/useRoleManagerClient"
 import useChange from "../../jacdac/useChange"
 import CmdButton from "../CmdButton"
+import Tooltip from "../ui/Tooltip"
 import { delay } from "../../../jacdac-ts/src/jdom/utils"
 
 export default function StartMissingSimulatorsButton(props: {
@@ -23,19 +24,35 @@ export default function StartMissingSimulatorsButton(props: {
     const disabled = !roleManager || allRolesBound
 
     if (disabled && hideOnDisabled) return null
+    
+    // TODO: i18n
+    const enabledTooltip = "Create a simulator for each Role without an assigned device"
+    const disabledTooltip = "This button becomes available if there are Roles without assignable devices"
 
+    // TODO: Clean up title prop
+    // The title prop is for default ui (rather than React) tooltips. Most buttons use React Tooltip
+    // Title is blanked to prevents two tooltips from showing
+    // aria describeby fulfilled by describeChild
     return (
-        <CmdButton
-            variant={variant}
-            trackName={trackName}
-            title="start missing simulators"
-            onClick={handleStartSimulators}
-            disabled={disabled}
-            icon={<DevicesIcon />}
+        <Tooltip
+          describeChild
+          title={ disabled ? disabledTooltip : enabledTooltip }
+          placement="bottom"
         >
-            {disabled && disabledChildren !== undefined
-                ? disabledChildren
-                : children}
-        </CmdButton>
+          <span>
+            <CmdButton
+                variant={variant}
+                trackName={trackName}
+                title=""
+                onClick={handleStartSimulators}
+                disabled={disabled}
+                icon={<DevicesIcon />}
+            >
+                {disabled && disabledChildren !== undefined
+                    ? disabledChildren
+                    : children}
+            </CmdButton>
+          </span>
+      </Tooltip>
     )
 }

--- a/src/components/makecode/MakeCodeAddBlocksButton.tsx
+++ b/src/components/makecode/MakeCodeAddBlocksButton.tsx
@@ -1,11 +1,10 @@
-import { Box } from "@mui/material"
+import Tooltip from "../ui/Tooltip"
 import { Button } from "gatsby-theme-material-ui"
 import React, { useMemo } from "react"
 import useChange from "../../jacdac/useChange"
 import IFrameBridgeClient from "./iframebridgeclient"
 import MakeCodeIcon from "../../components/icons/MakeCodeIcon"
 import useBus from "../../jacdac/useBus"
-import StartMissingSimulatorsButton from "../buttons/StartMissingSimulatorsButton"
 
 export default function MakeCodeAddBlocksButton() {
     const bus = useBus()
@@ -20,30 +19,33 @@ export default function MakeCodeAddBlocksButton() {
             /makecode/.test(window.location.href),
         []
     )
+    const isButtonEnabled = !!(extensions?.length);
+
+    //TODO: i18n
+    const enabledTooltip = "Add blocks for your connected and simulated devices to the modules drawer";
+    const disabledTooltip = "This button becomes available if you have devices connected that don't have their matching blocks added to the 'Modules' drawer";
 
     if (!isMakeCodeTool) return null
 
     return (
-        <Box m={1}>
-            {!!extensions?.length && (
-                <Button
-                    sx={{ mr: 1 }}
-                    size="medium"
-                    color="primary"
-                    variant="contained"
-                    startIcon={<MakeCodeIcon />}
-                    onClick={handleAdd}
-                    aria-label={"Add blocks"}
-                >
-                    Add blocks
-                </Button>
-            )}
-            <StartMissingSimulatorsButton
-                hideOnDisabled={true}
+        <Tooltip
+          describeChild
+          title={ isButtonEnabled ? enabledTooltip : disabledTooltip }
+          placement="bottom"
+        >
+          <span>
+            <Button
+                sx={{ mr: 1 }}
+                size="medium"
+                color="primary"
                 variant="contained"
+                disabled={!isButtonEnabled}
+                startIcon={<MakeCodeIcon />}
+                onClick={handleAdd}
             >
-                Start simulators
-            </StartMissingSimulatorsButton>
-        </Box>
+                Add blocks
+            </Button>
+          </span>
+        </Tooltip>
     )
 }

--- a/src/components/makecode/MakeCodeBlocksAndSimsBox.tsx
+++ b/src/components/makecode/MakeCodeBlocksAndSimsBox.tsx
@@ -1,0 +1,18 @@
+import { Box } from "@mui/material"
+import React from "react"
+import StartMissingSimulatorsButton from "../buttons/StartMissingSimulatorsButton"
+import MakeCodeAddBlocksButton from "./MakeCodeAddBlocksButton"
+
+export default function MakeCodeBlocksAndSimsBox() {
+
+  return (
+      <Box m={1}>
+        <MakeCodeAddBlocksButton />
+        <StartMissingSimulatorsButton
+        variant="contained"
+        >
+          Add Simulators
+        </StartMissingSimulatorsButton>
+      </Box>
+      )
+}

--- a/src/pages/tools/makecode-sim.tsx
+++ b/src/pages/tools/makecode-sim.tsx
@@ -8,7 +8,7 @@ import Dashboard from "../../components/dashboard/Dashboard"
 import DarkModeContext from "../../components/ui/DarkModeContext"
 import IFrameBridgeClient from "../../components/makecode/iframebridgeclient"
 import useBus from "../../jacdac/useBus"
-import MakeCodeAddBlocksButton from "../../components/makecode/MakeCodeAddBlocksButton"
+import MakeCodeBlocksAndSimsBox from "../../components/makecode/MakeCodeBlocksAndSimsBox"
 import { usePersistentSimulators } from "../../jacdac/usePersistentSimulators"
 
 /**
@@ -64,7 +64,7 @@ function Carousel() {
 
     return (
         <>
-            <MakeCodeAddBlocksButton />
+            <MakeCodeBlocksAndSimsBox />
             <Dashboard
                 showHeader={false}
                 showDeviceHeader={true}


### PR DESCRIPTION
* AddBlocks and StartMissingSimulators buttons are now visible when disabled
* Added React Tooltip for both buttons to explain behaviour
* Created a container component for StartMissingSimulators and AddBlocks rather than nesting them within each other
* Removed browser-styled tooltip from StartMissingSimulators

TODO: i18n
