### PR TITLE
Fix: All servo widgets displaying as continuous

### DIFF
--- a/src/components/dashboard/DashboardServo.tsx
+++ b/src/components/dashboard/DashboardServo.tsx
@@ -104,7 +104,7 @@ export default function DashboardServo(props: DashboardServiceProps) {
                     enabled={enabled}
                     toggleOff={toggleOff}
                     widgetSize={widgetSize}
-                    rotationRate={(throttle * rotationalSpeed) / 100}
+                    rotationRate={continuous ? (throttle * rotationalSpeed) / 100 : undefined}
                     visible={visible}
                 />
             </Grid>


### PR DESCRIPTION
rotationRate always had a value, added condition